### PR TITLE
fix: remove redundant editor instantiation

### DIFF
--- a/main.py
+++ b/main.py
@@ -300,10 +300,6 @@ class EditorWindow(QMainWindow):
         splitter.setStretchFactor(1, 1)
 
         root.addWidget(splitter, 1)
-        # ...
-        self.editor = QPlainTextEdit(self)
-        self.editor.setPlaceholderText("Escreva aqui…")
-        self.editor.setTabStopDistance(4 * self.editor.fontMetrics().width(' '))
 
         # Fonte monoespaçada (fica melhor para Markdown)
         f = self.editor.font()


### PR DESCRIPTION
## Summary
- remove duplicate creation of `self.editor` in `_build_ui`
- keep font and Markdown highlighter configuration for existing editor instance

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74d83c09883259de9536babe3ee36