### PR TITLE
feat: add sqlite migrations and repositories

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -8,11 +8,11 @@ from pydantic import BaseModel, Field
 class Character(BaseModel):
     name: str
     age: int = Field(ge=0)
-    city: Optional[str] = None
+    location: Optional[str] = None
     faction: Optional[str] = None
 
 
-class City(BaseModel):
+class Location(BaseModel):
     name: str
     population: int = Field(ge=0)
     region: Optional[str] = None
@@ -21,12 +21,23 @@ class City(BaseModel):
 class Faction(BaseModel):
     name: str
     description: Optional[str] = None
-    allies: List[str] = []
-    enemies: List[str] = []
+    allies: List[str] = Field(default_factory=list)
+    enemies: List[str] = Field(default_factory=list)
+
+
+class EconomyProfile(BaseModel):
+    name: str
+    gdp: float | None = None
+    notes: Optional[str] = None
 
 
 class TimelineEvent(BaseModel):
     description: str
     year: int
-    city: Optional[str] = None
-    factions_involved: List[str] = []
+    location: Optional[str] = None
+    factions_involved: List[str] = Field(default_factory=list)
+
+
+class World(BaseModel):
+    name: str
+    description: Optional[str] = None

--- a/infra/db.py
+++ b/infra/db.py
@@ -1,13 +1,110 @@
-"""Database utilities placeholder.
-
-This module is responsible for persistence layer interactions.
-"""
-
+"""SQLite database helpers with migrations, seeding and backups."""
 from __future__ import annotations
 
+import atexit
+import sqlite3
+from datetime import datetime
 from pathlib import Path
 
+from config import settings
 
-def get_db_path(base: Path) -> Path:
-    """Return the database file path under the given base directory."""
-    return base / "app.db"
+BASE_DIR = settings.workspace
+DB_PATH = BASE_DIR / "app.db"
+MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+BACKUP_DIR = BASE_DIR / "backups"
+
+
+def connect(seed: bool = False) -> sqlite3.Connection:
+    """Return a SQLite connection ensuring migrations are applied.
+
+    If *seed* is ``True`` demo data will be inserted when the database is
+    empty.
+    """
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    _run_migrations(conn)
+    if seed:
+        seed_demo(conn)
+    return conn
+
+
+def _run_migrations(conn: sqlite3.Connection) -> None:
+    """Apply all SQL migrations that have not yet been executed."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY)"
+    )
+    applied = {
+        row["id"] for row in conn.execute("SELECT id FROM schema_migrations")
+    }
+    for path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        mig_id = path.stem
+        if mig_id in applied:
+            continue
+        conn.executescript(path.read_text(encoding="utf-8"))
+        conn.execute(
+            "INSERT INTO schema_migrations (id) VALUES (?)", (mig_id,)
+        )
+        conn.commit()
+
+
+def seed_demo(conn: sqlite3.Connection) -> None:
+    """Insert demo data into empty tables."""
+    cur = conn.cursor()
+
+    cur.execute("SELECT COUNT(*) FROM worlds")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO worlds (name, description) VALUES (?, ?)",
+            ("Demo World", "Example world"),
+        )
+
+    cur.execute("SELECT COUNT(*) FROM locations")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO locations (name, population, region) VALUES (?, ?, ?)",
+            ("Springfield", 0, None),
+        )
+
+    cur.execute("SELECT COUNT(*) FROM factions")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO factions (name, description) VALUES (?, ?)",
+            ("Guild", "Local guild"),
+        )
+
+    cur.execute("SELECT COUNT(*) FROM characters")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO characters (name, age, location, faction) VALUES (?, ?, ?, ?)",
+            ("Alice", 30, "Springfield", "Guild"),
+        )
+
+    cur.execute("SELECT COUNT(*) FROM economy_profiles")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO economy_profiles (name, gdp, notes) VALUES (?, ?, ?)",
+            ("Default", 1000.0, "Example profile"),
+        )
+
+    cur.execute("SELECT COUNT(*) FROM timeline_events")
+    if cur.fetchone()[0] == 0:
+        cur.execute(
+            "INSERT INTO timeline_events (description, year, location, factions) VALUES (?, ?, ?, ?)",
+            ("Founding", 0, "Springfield", "Guild"),
+        )
+
+    conn.commit()
+
+
+def _backup() -> None:
+    """Create a timestamped backup of the database file."""
+    if not DB_PATH.exists():
+        return
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    dest = BACKUP_DIR / f"app-{ts}.db"
+    dest.write_bytes(DB_PATH.read_bytes())
+
+
+atexit.register(_backup)

--- a/infra/migrations/001_initial.sql
+++ b/infra/migrations/001_initial.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS characters (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    age INTEGER,
+    location TEXT,
+    faction TEXT
+);
+
+CREATE TABLE IF NOT EXISTS locations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    population INTEGER,
+    region TEXT
+);
+
+CREATE TABLE IF NOT EXISTS factions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS economy_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    gdp REAL,
+    notes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS timeline_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    description TEXT NOT NULL,
+    year INTEGER,
+    location TEXT,
+    factions TEXT
+);
+
+CREATE TABLE IF NOT EXISTS worlds (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT
+);

--- a/infra/repositories.py
+++ b/infra/repositories.py
@@ -1,0 +1,144 @@
+"""Repositories providing data access abstractions."""
+from __future__ import annotations
+
+import sqlite3
+
+from core import models
+
+
+class CharacterRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, character: models.Character) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO characters (name, age, location, faction) VALUES (?, ?, ?, ?)",
+            (character.name, character.age, character.location, character.faction),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.Character]:
+        cur = self.conn.execute(
+            "SELECT name, age, location, faction FROM characters"
+        )
+        return [
+            models.Character(
+                name=row[0], age=row[1], location=row[2], faction=row[3]
+            )
+            for row in cur.fetchall()
+        ]
+
+
+class LocationRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, location: models.Location) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO locations (name, population, region) VALUES (?, ?, ?)",
+            (location.name, location.population, location.region),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.Location]:
+        cur = self.conn.execute(
+            "SELECT name, population, region FROM locations"
+        )
+        return [
+            models.Location(name=row[0], population=row[1], region=row[2])
+            for row in cur.fetchall()
+        ]
+
+
+class FactionRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, faction: models.Faction) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO factions (name, description) VALUES (?, ?)",
+            (faction.name, faction.description),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.Faction]:
+        cur = self.conn.execute("SELECT name, description FROM factions")
+        return [
+            models.Faction(name=row[0], description=row[1])
+            for row in cur.fetchall()
+        ]
+
+
+class EconomyProfileRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, profile: models.EconomyProfile) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO economy_profiles (name, gdp, notes) VALUES (?, ?, ?)",
+            (profile.name, profile.gdp, profile.notes),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.EconomyProfile]:
+        cur = self.conn.execute("SELECT name, gdp, notes FROM economy_profiles")
+        return [
+            models.EconomyProfile(name=row[0], gdp=row[1], notes=row[2])
+            for row in cur.fetchall()
+        ]
+
+
+class TimelineEventRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, event: models.TimelineEvent) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO timeline_events (description, year, location, factions) VALUES (?, ?, ?, ?)",
+            (
+                event.description,
+                event.year,
+                event.location,
+                ",".join(event.factions_involved),
+            ),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.TimelineEvent]:
+        cur = self.conn.execute(
+            "SELECT description, year, location, factions FROM timeline_events"
+        )
+        return [
+            models.TimelineEvent(
+                description=row[0],
+                year=row[1],
+                location=row[2],
+                factions_involved=[f for f in row[3].split(",") if f],
+            )
+            for row in cur.fetchall()
+        ]
+
+
+class WorldRepo:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, world: models.World) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO worlds (name, description) VALUES (?, ?)",
+            (world.name, world.description),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def list(self) -> list[models.World]:
+        cur = self.conn.execute("SELECT name, description FROM worlds")
+        return [
+            models.World(name=row[0], description=row[1])
+            for row in cur.fetchall()
+        ]


### PR DESCRIPTION
## Summary
- define pydantic models for location, economy profile and world
- add SQLite helper with migrations, seeding and backups
- implement repositories for characters, locations, factions, economy profiles, timeline events and worlds

## Testing
- `python -m pytest`
- `pre-commit run --files core/models.py infra/db.py infra/repositories.py infra/migrations/__init__.py infra/migrations/001_initial.sql` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8801837ec8325bb0655f0f13be317