### PR TITLE
refactor: externalize theme tokens

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,12 +12,40 @@ load_dotenv()
 
 @dataclass
 class Config:
-    """Application configuration loaded from environment variables."""
+    """Application configuration loaded from environment variables.
+
+    Theme preference can be overridden by a user settings file
+    located in the application workspace.
+    """
 
     workspace: Path = Path(os.getenv("APP_WORKSPACE", "data"))
     language: str = os.getenv("APP_LANGUAGE", "pt-br")
     theme: str = os.getenv("APP_THEME", "light")
     debug: bool = os.getenv("APP_DEBUG", "0") == "1"
 
+    def load_user_settings(self) -> None:
+        """Load user settings from ``settings.json`` if available."""
+
+        path = self.workspace / "settings.json"
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.theme = data.get("theme", self.theme)
+
+    def save_theme(self, theme: str) -> None:
+        """Persist the selected *theme* to the workspace settings file."""
+
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        path = self.workspace / "settings.json"
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        else:
+            data = {}
+        data["theme"] = theme
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
 
 settings = Config()
+settings.load_user_settings()

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,46 +1,50 @@
+import json
+from pathlib import Path
+
 from PyQt5.QtWidgets import QApplication
 
-THEMES = {
-    "light": {
-        "--bg": "#ffffff",
-        "--panel": "#f0f0f0",
-        "--text": "#000000",
-        "--accent": "#0078d4",
-        "--border": "#d0d0d0",
-    },
-    "dark": {
-        "--bg": "#131417",
-        "--panel": "#1a1c22",
-        "--text": "#e6e6e6",
-        "--accent": "#86b7ff",
-        "--border": "#2a2d36",
-    },
-    "sepia": {
-        "--bg": "#f5efe6",
-        "--panel": "#fffaf2",
-        "--text": "#2b2a27",
-        "--accent": "#3b6fb6",
-        "--border": "#e2d7c7",
-    },
-}
+from config import settings
+
+_TOKENS_PATH = Path(__file__).with_name("tokens.json")
+with _TOKENS_PATH.open("r", encoding="utf-8") as fh:
+    TOKENS = json.load(fh)
 
 
 def _build_stylesheet(palette: dict) -> str:
+    typography = TOKENS.get("typography", {})
+    spacing = TOKENS.get("spacing", {})
+    padding = spacing.get("padding", "4px 8px")
+    button_height = spacing.get("button_height", "24px")
+    font_size = typography.get("base_size", "14px")
+    font_family = typography.get("font_family", "sans-serif")
+
     return f"""
-    QMainWindow {{ background: {palette['--bg']}; color: {palette['--text']}; }}
-    QToolBar {{ background: {palette['--panel']}; border: 0; }}
-    QTreeView {{ background: {palette['--panel']}; color: {palette['--text']}; border-right: 1px solid {palette['--border']}; }}
-    QPlainTextEdit {{ background: {palette['--panel']}; color: {palette['--text']}; selection-background-color: {palette['--accent']}; }}
-    QStatusBar {{ background: {palette['--panel']}; color: {palette['--text']}; border-top: 1px solid {palette['--border']}; }}
-    QLineEdit, QPushButton {{ background: {palette['--panel']}; color: {palette['--text']}; border: 1px solid {palette['--border']}; padding: 4px 8px; }}
-    QPushButton:hover {{ border-color: {palette['--accent']}; }}
-    QMenu {{ background: {palette['--panel']}; color: {palette['--text']}; border: 1px solid {palette['--border']}; }}
+    QWidget {{ font-size: {font_size}; font-family: {font_family}; }}
+    QMainWindow {{ background: {palette['bg']}; color: {palette['text']}; }}
+    QToolBar {{ background: {palette['panel']}; border: 0; }}
+    QTreeView {{ background: {palette['panel']}; color: {palette['text']}; border-right: 1px solid {palette['border']}; }}
+    QPlainTextEdit {{ background: {palette['panel']}; color: {palette['text']}; selection-background-color: {palette['accent']}; }}
+    QStatusBar {{ background: {palette['panel']}; color: {palette['text']}; border-top: 1px solid {palette['border']}; }}
+    QLineEdit, QPushButton {{ background: {palette['panel']}; color: {palette['text']}; border: 1px solid {palette['border']}; padding: {padding}; min-height: {button_height}; }}
+    QPushButton:hover {{ border-color: {palette['accent']}; }}
+    QMenu {{ background: {palette['panel']}; color: {palette['text']}; border: 1px solid {palette['border']}; }}
+    *:focus {{ outline: 2px solid {palette['accent']}; }}
     """
 
 
+def as_css_variables(theme: str) -> str:
+    """Return CSS variable declarations for *theme*."""
+
+    palette = TOKENS["themes"].get(theme, TOKENS["themes"]["light"])
+    lines = [f"--{key}: {value};" for key, value in palette.items()]
+    return ":root{\n    " + "\n    ".join(lines) + "\n}"
+
+
 def apply_theme(theme: str) -> None:
-    """Apply *theme* to the current QApplication."""
-    palette = THEMES.get(theme, THEMES["light"])
+    """Apply *theme* to the current QApplication and persist selection."""
+
+    palette = TOKENS["themes"].get(theme, TOKENS["themes"]["light"])
+    settings.save_theme(theme)
     app = QApplication.instance()
     if app:
         app.setStyleSheet(_build_stylesheet(palette))

--- a/ui/tokens.json
+++ b/ui/tokens.json
@@ -1,0 +1,33 @@
+{
+  "themes": {
+    "light": {
+      "bg": "#ffffff",
+      "panel": "#f0f0f0",
+      "text": "#000000",
+      "accent": "#0078d4",
+      "border": "#d0d0d0"
+    },
+    "dark": {
+      "bg": "#131417",
+      "panel": "#1a1c22",
+      "text": "#e6e6e6",
+      "accent": "#86b7ff",
+      "border": "#2a2d36"
+    },
+    "high_contrast": {
+      "bg": "#000000",
+      "panel": "#000000",
+      "text": "#ffffff",
+      "accent": "#ffff00",
+      "border": "#ffffff"
+    }
+  },
+  "typography": {
+    "base_size": "14px",
+    "font_family": "Arial, sans-serif"
+  },
+  "spacing": {
+    "padding": "4px 8px",
+    "button_height": "24px"
+  }
+}


### PR DESCRIPTION
## Summary
- load theme tokens from new tokens.json with light, dark, and high-contrast palettes
- refactor theme application to use tokens and persist user selection
- allow configuration to read/write theme preference in workspace settings

## Testing
- `pre-commit run --files config.py ui/theme.py ui/tokens.json` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `python - <<'PY'
from ui import theme
print(theme.as_css_variables('high_contrast').splitlines()[0])
PY` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b883d83f7083258d53e58cd2bf03e3