### PR TITLE
feat: expand timeline events and visualization

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,15 +1,24 @@
+"""Domain models for the world builder application."""
+
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class Character(BaseModel):
+    """Representation of a character in the world."""
+
     name: str
-    age: int = Field(ge=0)
+    birth_year: int = Field(ge=-10_000)
     location: Optional[str] = None
     faction: Optional[str] = None
+
+    @property
+    def age(self) -> int:
+        """Return the age of the character relative to year 0."""
+        return -self.birth_year
 
 
 class Location(BaseModel):
@@ -32,10 +41,40 @@ class EconomyProfile(BaseModel):
 
 
 class TimelineEvent(BaseModel):
-    description: str
+    """Event registered on the timeline."""
+
+    id: str
+    title: str
     year: int
-    location: Optional[str] = None
-    factions_involved: List[str] = Field(default_factory=list)
+    era: Optional[str] = None
+    scope: str = Field(default="local")  # local/personagem/mundo
+    description: str = ""
+    character_ids: List[str] = Field(default_factory=list)
+    location_ids: List[str] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
+
+    @validator("scope")
+    def _validate_scope(cls, value: str) -> str:
+        allowed = {"local", "personagem", "mundo"}
+        if value not in allowed:
+            raise ValueError(f"scope must be one of {allowed}")
+        return value
+
+
+def validate_event_characters(
+    event: TimelineEvent, characters: Dict[str, Character]
+) -> None:
+    """Validate that characters appear only after their birth year.
+
+    Raises a ``ValueError`` if the event year precedes a character's birth year.
+    """
+
+    for char_id in event.character_ids:
+        char = characters.get(char_id)
+        if char and event.year < char.birth_year:
+            raise ValueError(
+                f"Character '{char.name}' appears in {event.title} before their birth"
+            )
 
 
 class World(BaseModel):

--- a/infra/db.py
+++ b/infra/db.py
@@ -76,8 +76,8 @@ def seed_demo(conn: sqlite3.Connection) -> None:
     cur.execute("SELECT COUNT(*) FROM characters")
     if cur.fetchone()[0] == 0:
         cur.execute(
-            "INSERT INTO characters (name, age, location, faction) VALUES (?, ?, ?, ?)",
-            ("Alice", 30, "Springfield", "Guild"),
+            "INSERT INTO characters (name, birth_year, location, faction) VALUES (?, ?, ?, ?)",
+            ("Alice", -30, "Springfield", "Guild"),
         )
 
     cur.execute("SELECT COUNT(*) FROM economy_profiles")
@@ -90,8 +90,11 @@ def seed_demo(conn: sqlite3.Connection) -> None:
     cur.execute("SELECT COUNT(*) FROM timeline_events")
     if cur.fetchone()[0] == 0:
         cur.execute(
-            "INSERT INTO timeline_events (description, year, location, factions) VALUES (?, ?, ?, ?)",
-            ("Founding", 0, "Springfield", "Guild"),
+            (
+                "INSERT INTO timeline_events (id, title, year, era, scope, description, characters, locations, tags) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            ("evt-1", "Founding", 0, None, "local", "Founding", "", "Springfield", "Guild"),
         )
 
     conn.commit()

--- a/infra/migrations/001_initial.sql
+++ b/infra/migrations/001_initial.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS characters (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    age INTEGER,
+    birth_year INTEGER,
     location TEXT,
     faction TEXT
 );
@@ -27,11 +27,15 @@ CREATE TABLE IF NOT EXISTS economy_profiles (
 );
 
 CREATE TABLE IF NOT EXISTS timeline_events (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    description TEXT NOT NULL,
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
     year INTEGER,
-    location TEXT,
-    factions TEXT
+    era TEXT,
+    scope TEXT,
+    description TEXT,
+    characters TEXT,
+    locations TEXT,
+    tags TEXT
 );
 
 CREATE TABLE IF NOT EXISTS worlds (

--- a/infra/repositories.py
+++ b/infra/repositories.py
@@ -12,19 +12,19 @@ class CharacterRepo:
 
     def add(self, character: models.Character) -> int:
         cur = self.conn.execute(
-            "INSERT INTO characters (name, age, location, faction) VALUES (?, ?, ?, ?)",
-            (character.name, character.age, character.location, character.faction),
+            "INSERT INTO characters (name, birth_year, location, faction) VALUES (?, ?, ?, ?)",
+            (character.name, character.birth_year, character.location, character.faction),
         )
         self.conn.commit()
         return cur.lastrowid
 
     def list(self) -> list[models.Character]:
         cur = self.conn.execute(
-            "SELECT name, age, location, faction FROM characters"
+            "SELECT name, birth_year, location, faction FROM characters"
         )
         return [
             models.Character(
-                name=row[0], age=row[1], location=row[2], faction=row[3]
+                name=row[0], birth_year=row[1], location=row[2], faction=row[3]
             )
             for row in cur.fetchall()
         ]
@@ -98,12 +98,20 @@ class TimelineEventRepo:
 
     def add(self, event: models.TimelineEvent) -> int:
         cur = self.conn.execute(
-            "INSERT INTO timeline_events (description, year, location, factions) VALUES (?, ?, ?, ?)",
             (
-                event.description,
+                "INSERT INTO timeline_events (id, title, year, era, scope, description, characters, locations, tags) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                event.id,
+                event.title,
                 event.year,
-                event.location,
-                ",".join(event.factions_involved),
+                event.era,
+                event.scope,
+                event.description,
+                ",".join(event.character_ids),
+                ",".join(event.location_ids),
+                ",".join(event.tags),
             ),
         )
         self.conn.commit()
@@ -111,14 +119,22 @@ class TimelineEventRepo:
 
     def list(self) -> list[models.TimelineEvent]:
         cur = self.conn.execute(
-            "SELECT description, year, location, factions FROM timeline_events"
+            (
+                "SELECT id, title, year, era, scope, description, characters, locations, tags "
+                "FROM timeline_events"
+            )
         )
         return [
             models.TimelineEvent(
-                description=row[0],
-                year=row[1],
-                location=row[2],
-                factions_involved=[f for f in row[3].split(",") if f],
+                id=row[0],
+                title=row[1],
+                year=row[2],
+                era=row[3],
+                scope=row[4],
+                description=row[5],
+                character_ids=[c for c in row[6].split(",") if c],
+                location_ids=[loc for loc in row[7].split(",") if loc],
+                tags=[t for t in row[8].split(",") if t],
             )
             for row in cur.fetchall()
         ]


### PR DESCRIPTION
## Summary
- enrich timeline event model with ids, scope, links and tags
- add birth-year validation for event participants
- upgrade timeline UI with filtering, zoom and draggable events

## Testing
- `pytest`
- `ruff check core/models.py infra/repositories.py infra/db.py`
- `ruff check ui/linha_do_tempo.py` *(fails: unused imports and style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b8852dfd88832593b8e6526746349d