### PR TITLE
Add base entity model and relation graph

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -7,10 +7,18 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field, validator
 
 
-class Character(BaseModel):
-    """Representation of a character in the world."""
+class BaseEntity(BaseModel):
+    """Common reusable fields for world entities."""
 
     name: str
+    summary: str | None = None
+    tags: List[str] = Field(default_factory=list)
+    relations: List[str] = Field(default_factory=list)
+
+
+class Character(BaseEntity):
+    """Representation of a character in the world."""
+
     birth_year: int = Field(ge=-10_000)
     location: Optional[str] = None
     faction: Optional[str] = None
@@ -21,21 +29,17 @@ class Character(BaseModel):
         return -self.birth_year
 
 
-class Location(BaseModel):
-    name: str
+class Location(BaseEntity):
     population: int = Field(ge=0)
     region: Optional[str] = None
 
 
-class Faction(BaseModel):
-    name: str
-    description: Optional[str] = None
+class Faction(BaseEntity):
     allies: List[str] = Field(default_factory=list)
     enemies: List[str] = Field(default_factory=list)
 
 
-class EconomyProfile(BaseModel):
-    name: str
+class EconomyProfile(BaseEntity):
     gdp: float | None = None
     notes: Optional[str] = None
 
@@ -77,6 +81,5 @@ def validate_event_characters(
             )
 
 
-class World(BaseModel):
-    name: str
+class World(BaseEntity):
     description: Optional[str] = None

--- a/core/relations.py
+++ b/core/relations.py
@@ -1,0 +1,67 @@
+"""Utility classes for managing bidirectional relations between entities.
+
+The :class:`RelationGraph` provides a lightweight interface around
+``networkx`` to register entities (characters, factions, locations, etc.)
+with bidirectional edges. It can be exported to a ``networkx.Graph`` for
+visualisation with any backend (matplotlib, pyvis, ...).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import networkx as nx
+
+
+class RelationGraph:
+    """Maintain bidirectional relations between world entities.
+
+    Nodes are referenced by a unique identifier (typically the entity name).
+    Edges are undirected and may carry a ``relation`` attribute describing
+    the type of connection.
+    """
+
+    def __init__(self) -> None:
+        self._graph = nx.Graph()
+
+    def add_entity(self, entity_id: str, **attrs: object) -> None:
+        """Register a new entity node in the graph."""
+
+        self._graph.add_node(entity_id, **attrs)
+
+    def add_relation(self, a: str, b: str, relation: str) -> None:
+        """Create a bidirectional relation between ``a`` and ``b``."""
+
+        self._graph.add_edge(a, b, relation=relation)
+
+    def remove_relation(self, a: str, b: str) -> None:
+        """Remove the relation between ``a`` and ``b`` if it exists."""
+
+        if self._graph.has_edge(a, b):
+            self._graph.remove_edge(a, b)
+
+    def relations_of(self, entity_id: str) -> Iterable[tuple[str, str]]:
+        """Iterate over relations for ``entity_id``.
+
+        Yields tuples of ``(other_id, relation_type)``.
+        """
+
+        for other, data in self._graph[entity_id].items():
+            yield other, data.get("relation", "")
+
+    def to_networkx(self) -> nx.Graph:
+        """Return the underlying ``networkx`` graph instance."""
+
+        return self._graph
+
+    def plot(self) -> None:  # pragma: no cover - optional UI helper
+        """Quick visualisation using ``matplotlib``.
+
+        This method imports ``matplotlib`` lazily to avoid forcing the
+        dependency for users that only need the data structure.
+        """
+
+        import matplotlib.pyplot as plt
+
+        nx.draw_networkx(self._graph)
+        plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PyQt5
 pyspellchecker
 pydantic
 python-dotenv
+networkx
+matplotlib


### PR DESCRIPTION
## Summary
- introduce `BaseEntity` with reusable summary, tags and relations fields
- create `RelationGraph` utility built on networkx for bidirectional relationships
- add graph dependencies

## Testing
- `python -m py_compile core/models.py core/relations.py`
- `ruff check core/models.py core/relations.py`
- `pip install networkx matplotlib` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_e_68b887fc5ab483258877fb721d329d83