### PR TITLE
Handle encoding errors when importing batch files

### DIFF
--- a/core/io.py
+++ b/core/io.py
@@ -71,7 +71,11 @@ def import_batch(src: Path, dest_workspace: Path) -> None:
                 if file.suffix.lower() not in {".md", ".txt"}:
                     continue
                 target = dest_chap / file.name
-                target.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
+                try:
+                    text = file.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    text = file.read_text(encoding="latin-1")
+                target.write_text(text, encoding="utf-8")
 
 
 def export_modules(workspace: Path, modules: Iterable[str], dest_zip: Path) -> None:


### PR DESCRIPTION
## Summary
- handle non-UTF-8 files when importing batches by falling back to latin-1

## Testing
- `pytest -q`
- `pre-commit run --files core/io.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88eb72bc48325b350f31dcb1e51d0