### PR TITLE
Add coherence report and telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/__pycache__/
 .env
 /shared/__pycache__
 /ui/__pycache__
+**/__pycache__/

--- a/core/coherence.py
+++ b/core/coherence.py
@@ -1,0 +1,73 @@
+"""Utilities for generating coherence reports across world data."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .models import Faction, TimelineEvent
+
+
+@dataclass
+class CharacterOverlap:
+    """Represents a character appearing in multiple locations in the same year."""
+
+    character: str
+    year: int
+    locations: List[str]
+
+
+@dataclass
+class CoherenceReport:
+    """Aggregated inconsistencies found in the world data."""
+
+    conflicting_dates: List[str]
+    character_overlaps: List[CharacterOverlap]
+    duplicate_factions: List[str]
+
+
+def generate_report(
+    events: Iterable[TimelineEvent], factions: Iterable[Faction]
+) -> CoherenceReport:
+    """Inspect *events* and *factions* to detect common consistency issues.
+
+    The function checks for:
+
+    * conflicting dates: multiple events with the same identifier but different years
+    * character overlaps: a character assigned to different locations in the same year
+    * duplicate factions: repeated faction names
+    """
+
+    conflicting: dict[str, int] = {}
+    conflicting_dates: set[str] = set()
+    char_year_locs: dict[str, dict[int, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+
+    for ev in events:
+        prev = conflicting.get(ev.id)
+        if prev is not None and prev != ev.year:
+            conflicting_dates.add(ev.id)
+        conflicting[ev.id] = ev.year
+        for char in ev.character_ids:
+            char_year_locs[char][ev.year].update(ev.location_ids)
+
+    overlaps: List[CharacterOverlap] = []
+    for char, years in char_year_locs.items():
+        for year, locs in years.items():
+            if len(locs) > 1:
+                overlaps.append(CharacterOverlap(char, year, sorted(locs)))
+
+    faction_names: dict[str, int] = defaultdict(int)
+    duplicates: List[str] = []
+    for f in factions:
+        faction_names[f.name] += 1
+        if faction_names[f.name] == 2:
+            duplicates.append(f.name)
+
+    return CoherenceReport(
+        conflicting_dates=sorted(conflicting_dates),
+        character_overlaps=overlaps,
+        duplicate_factions=duplicates,
+    )

--- a/infra/telemetry.py
+++ b/infra/telemetry.py
@@ -1,0 +1,42 @@
+"""Simple opt-in telemetry collector.
+
+The telemetry client stores usage metrics in a local JSON file. No data is
+sent externally. Users must explicitly enable it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass
+class Telemetry:
+    """Collects usage events when ``enabled`` is true."""
+
+    path: Path
+    enabled: bool = False
+    _events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.enabled and self.path.exists():
+            try:
+                data = json.loads(self.path.read_text(encoding="utf-8"))
+                self._events = data.get("events", [])
+            except Exception:
+                self._events = []
+
+    def track(self, name: str, payload: Dict[str, Any] | None = None) -> None:
+        """Record an event with *name* and optional *payload*."""
+        if not self.enabled:
+            return
+        event: Dict[str, Any] = {"name": name}
+        if payload:
+            event["payload"] = payload
+        self._events.append(event)
+        self.path.write_text(
+            json.dumps({"events": self._events}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.coherence import CharacterOverlap, generate_report
+from core.models import Faction, TimelineEvent
+
+
+def test_generate_report_detects_inconsistencies() -> None:
+    events = [
+        TimelineEvent(
+            id="e1", title="Battle", year=10, character_ids=["c1"], location_ids=["l1"]
+        ),
+        TimelineEvent(
+            id="e1",
+            title="Battle duplicate",
+            year=12,
+            character_ids=["c1"],
+            location_ids=["l1"],
+        ),
+        TimelineEvent(
+            id="e2", title="Trip1", year=15, character_ids=["c1"], location_ids=["l1"]
+        ),
+        TimelineEvent(
+            id="e3", title="Trip2", year=15, character_ids=["c1"], location_ids=["l2"]
+        ),
+    ]
+    factions = [Faction(name="A"), Faction(name="A"), Faction(name="B")]
+
+    report = generate_report(events, factions)
+
+    assert report.conflicting_dates == ["e1"]
+    assert CharacterOverlap("c1", 15, ["l1", "l2"]) in report.character_overlaps
+    assert report.duplicate_factions == ["A"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,23 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from infra.telemetry import Telemetry
+
+
+def test_telemetry_tracks_events(tmp_path) -> None:
+    path = tmp_path / "telemetry.json"
+    t = Telemetry(path, enabled=True)
+    t.track("start", {"val": 1})
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["events"][0]["name"] == "start"
+    assert data["events"][0]["payload"] == {"val": 1}
+
+
+def test_telemetry_disabled(tmp_path) -> None:
+    path = tmp_path / "telemetry.json"
+    t = Telemetry(path, enabled=False)
+    t.track("start")
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- add coherence report to detect conflicting dates, character overlaps and duplicate factions
- implement opt-in telemetry that records local usage metrics
- add tests for coherence and telemetry utilities

## Testing
- `ruff check --fix core/coherence.py infra/telemetry.py tests/test_coherence.py tests/test_telemetry.py`
- `ruff format core/coherence.py infra/telemetry.py tests/test_coherence.py tests/test_telemetry.py`
- `isort core/coherence.py infra/telemetry.py tests/test_coherence.py tests/test_telemetry.py`
- `black core/coherence.py infra/telemetry.py tests/test_coherence.py tests/test_telemetry.py`
- `mypy core/coherence.py infra/telemetry.py tests/test_coherence.py tests/test_telemetry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89112a7a48325a3aafc704eb8e945