### PR TITLE
Add tests and simple CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pre-commit
+      - name: Run linters and tests
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,11 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/tests/test_exports_snapshot.py
+++ b/tests/test_exports_snapshot.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.io import export_text
+
+
+def test_export_text_html_snapshot(tmp_path):
+    path = tmp_path / "out.html"
+    export_text("Hello & <World>\nLine2", path)
+    content = path.read_text(encoding="utf-8")
+    expected = (
+        "<!DOCTYPE html><html><head><meta charset='utf-8'></head><body>"
+        "Hello &amp; &lt;World&gt;<br/>\nLine2</body></html>"
+    )
+    assert content == expected
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.models import Character, TimelineEvent, validate_event_characters
+
+
+def test_validate_event_characters_allows_valid_event() -> None:
+    char = Character(name="Alice", birth_year=-10)
+    event = TimelineEvent(id="e1", title="Meeting", year=0, character_ids=["c1"])
+    validate_event_characters(event, {"c1": char})
+
+
+def test_validate_event_characters_raises_for_early_event() -> None:
+    char = Character(name="Bob", birth_year=10)
+    event = TimelineEvent(id="e1", title="Birth", year=0, character_ids=["c1"])
+    with pytest.raises(ValueError):
+        validate_event_characters(event, {"c1": char})

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,28 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.models import Character
+from infra.repositories import CharacterRepo
+
+
+def test_character_repo_add_and_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("APP_WORKSPACE", str(tmp_path))
+    import config
+    import infra.db as db
+
+    importlib.reload(config)
+    importlib.reload(db)
+
+    conn = db.connect()
+    repo = CharacterRepo(conn)
+    repo.add(Character(name="Eve", birth_year=-20))
+
+    characters = repo.list()
+    assert any(c.name == "Eve" for c in characters)
+


### PR DESCRIPTION
## Summary
- add unit, integration, and snapshot tests
- run pytest through pre-commit and add GitHub Actions workflow

## Testing
- `pytest`
- `pre-commit run --files .pre-commit-config.yaml tests/test_exports_snapshot.py tests/test_models.py tests/test_repositories.py .github/workflows/ci.yml` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b893d8eb8883259d7ca730302cfd19