### PR TITLE
Add basic pt-BR/EN i18n support via string catalog

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,6 +31,7 @@ class Config:
             with path.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)
             self.theme = data.get("theme", self.theme)
+            self.language = data.get("language", self.language)
 
     def save_theme(self, theme: str) -> None:
         """Persist the selected *theme* to the workspace settings file."""

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
 from config import settings
+from shared.i18n import t
 from shared.logging import get_logger
 from shared.utils import ensure_dir
 from ui.editor import EditorWindow
@@ -23,8 +24,8 @@ def main():
         logger.exception("Unhandled error")
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Critical)
-        msg.setWindowTitle("Erro")
-        msg.setText("Ocorreu um erro inesperado.")
+        msg.setWindowTitle(t("error.title"))
+        msg.setText(t("error.unexpected"))
         msg.setInformativeText(str(exc))
         msg.exec_()
 

--- a/shared/i18n.py
+++ b/shared/i18n.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from config import settings
+
+CATALOG: Dict[str, Dict[str, str]] = {
+    "pt-br": {
+        "error.title": "Erro",
+        "error.unexpected": "Ocorreu um erro inesperado.",
+    },
+    "en": {
+        "error.title": "Error",
+        "error.unexpected": "An unexpected error occurred.",
+    },
+}
+
+
+def t(key: str) -> str:
+    """Return translated string for *key* using the configured language."""
+    lang = settings.language.lower()
+    catalog = CATALOG.get(lang, CATALOG["en"])
+    return catalog.get(key, key)


### PR DESCRIPTION
## Summary
- support language preference from user settings
- provide simple pt-BR/EN translation catalog
- use catalog for error dialog messaging

## Testing
- `ruff check --fix main.py config.py shared/i18n.py`
- `ruff format main.py config.py shared/i18n.py`
- `isort --profile=black main.py config.py shared/i18n.py`
- `black main.py config.py shared/i18n.py`
- `mypy main.py` *(fails: Item "None" of "QHeaderView | None" has no attribute "setVisible")*
- `mypy config.py shared/i18n.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b895176aa08325ada8734af29c2c0a