### PR TITLE
feat: add theme token scales and persistence

### DIFF
--- a/shared/theme_tokens.py
+++ b/shared/theme_tokens.py
@@ -1,0 +1,35 @@
+"""Design token scales for spacing, radius and z-index.
+
+This module centralizes CSS variable values shared across themes.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Spacing scale --space-1..8
+SPACE_SCALE: Dict[str, str] = {f"--space-{i}": f"{i * 4}px" for i in range(1, 9)}
+
+# Border radius scale --radius-1..4
+RADIUS_SCALE: Dict[str, str] = {
+    "--radius-1": "2px",
+    "--radius-2": "4px",
+    "--radius-3": "8px",
+    "--radius-4": "16px",
+}
+
+# Z-index scale --z-1..10
+Z_INDEX_SCALE: Dict[str, str] = {f"--z-{i}": str(i * 10) for i in range(1, 11)}
+
+
+def tokens() -> Dict[str, str]:
+    """Return all token variables as a flat mapping."""
+
+    result: Dict[str, str] = {}
+    result.update(SPACE_SCALE)
+    result.update(RADIUS_SCALE)
+    result.update(Z_INDEX_SCALE)
+    return result
+
+
+__all__ = ["SPACE_SCALE", "RADIUS_SCALE", "Z_INDEX_SCALE", "tokens"]

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -1,0 +1,38 @@
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def test_theme_persistence(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+    # Stub PyQt5 dependencies before importing theme
+    qt_module = types.ModuleType("PyQt5")
+    widgets_module = types.ModuleType("PyQt5.QtWidgets")
+
+    class DummyApp:
+        @staticmethod
+        def instance():
+            return None
+
+    widgets_module.QApplication = DummyApp
+    qt_module.QtWidgets = widgets_module
+    sys.modules.setdefault("PyQt5", qt_module)
+    sys.modules.setdefault("PyQt5.QtWidgets", widgets_module)
+
+    # Reload modules so CONFIG_FILE points inside tmp_path
+    from shared import constants as const
+
+    importlib.reload(const)
+    import ui.theme as theme
+
+    importlib.reload(theme)
+
+    theme.apply_theme("dark", project_id="proj", user_id="user")
+    assert const.CONFIG_FILE.exists()
+    data = json.loads(const.CONFIG_FILE.read_text(encoding="utf-8"))
+    assert data["themes"]["proj"]["user"] == "dark"
+    assert theme.load_theme("proj", "user") == "dark"

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,9 +1,12 @@
 import json
 from pathlib import Path
+from typing import Dict
 
 from PyQt5.QtWidgets import QApplication
 
 from config import settings
+from shared.constants import CONFIG_FILE
+from shared.theme_tokens import tokens as token_variables
 
 _TOKENS_PATH = Path(__file__).with_name("tokens.json")
 with _TOKENS_PATH.open("r", encoding="utf-8") as fh:
@@ -11,6 +14,7 @@ with _TOKENS_PATH.open("r", encoding="utf-8") as fh:
 
 # 🔹 Exportar os temas disponíveis
 THEMES = TOKENS.get("themes", {})
+
 
 def _build_stylesheet(palette: dict) -> str:
     typography = TOKENS.get("typography", {})
@@ -35,18 +39,50 @@ def _build_stylesheet(palette: dict) -> str:
 
 
 def as_css_variables(theme: str) -> str:
-    """Return CSS variable declarations for *theme*."""
+    """Return CSS variable declarations for *theme* including shared tokens."""
 
     palette = TOKENS["themes"].get(theme, TOKENS["themes"]["light"])
     lines = [f"--{key}: {value};" for key, value in palette.items()]
+    for name, value in token_variables().items():
+        lines.append(f"{name}: {value};")
     return ":root{\n    " + "\n    ".join(lines) + "\n}"
 
 
-def apply_theme(theme: str) -> None:
+def _save_theme_selection(project_id: str, user_id: str, theme: str) -> None:
+    """Persist *theme* for a given *project_id* and *user_id*."""
+
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+            data: Dict[str, Dict] = json.load(fh)
+    else:
+        data = {}
+    themes = data.setdefault("themes", {})
+    project = themes.setdefault(project_id, {})
+    project[user_id] = theme
+    with CONFIG_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+
+
+def load_theme(project_id: str, user_id: str, default: str = settings.theme) -> str:
+    """Return stored theme for *project_id* and *user_id*.
+
+    Falls back to *default* if nothing was persisted.
+    """
+
+    if CONFIG_FILE.exists():
+        with CONFIG_FILE.open("r", encoding="utf-8") as fh:
+            data: Dict[str, Dict] = json.load(fh)
+        return data.get("themes", {}).get(project_id, {}).get(user_id, default)
+    return default
+
+
+def apply_theme(
+    theme: str, project_id: str = "default_project", user_id: str = "default_user"
+) -> None:
     """Apply *theme* to the current QApplication and persist selection."""
 
     palette = TOKENS["themes"].get(theme, TOKENS["themes"]["light"])
-    settings.save_theme(theme)
+    _save_theme_selection(project_id, user_id, theme)
     app = QApplication.instance()
     if app:
         app.setStyleSheet(_build_stylesheet(palette))


### PR DESCRIPTION
## Summary
- centralize spacing, radius and z-index design tokens
- persist user and project theme selection and expose loader
- add regression test for theme persistence

## Testing
- `ruff check shared/theme_tokens.py ui/theme.py ui/editor.py main.py tests/test_theme_persistence.py` (fails: unused imports and E701 errors in `ui/editor.py`)
- `black --check shared/theme_tokens.py ui/theme.py main.py tests/test_theme_persistence.py`
- `isort --check-only shared/theme_tokens.py ui/theme.py main.py tests/test_theme_persistence.py`
- `mypy shared/theme_tokens.py ui/theme.py main.py tests/test_theme_persistence.py` (fails: missing attributes in Qt stubs and other modules)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89d7bab7883259b416a902324c20d