### PR TITLE
feat: timeline service and quick-create events

### DIFF
--- a/core/timeline/service.py
+++ b/core/timeline/service.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+import uuid
+
+
+@dataclass
+class Evento:
+    """Representa um evento na linha do tempo."""
+
+    titulo: str
+    instante: int
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    tipo: str = "Geral"
+    importancia: int = 3
+    escopo: str = "local"
+    descricao: str = ""
+    era: str = ""
+    tags: List[str] = field(default_factory=list)
+    depende_de: List[str] = field(default_factory=list)
+    personagens: List[str] = field(default_factory=list)
+    lugares: List[str] = field(default_factory=list)
+
+
+class TimelineService:
+    """Serviço para manipulação de eventos de linha do tempo."""
+
+    def __init__(self, eventos: Iterable[Evento] | None = None) -> None:
+        self.eventos: List[Evento] = list(eventos or [])
+
+    def add_event(self, evento: Evento) -> None:
+        """Adiciona um evento e mantém a ordenação."""
+        self.eventos.append(evento)
+        self.sort_events()
+
+    def sort_events(self) -> List[Evento]:
+        """Ordena eventos por instante e título."""
+        self.eventos.sort(key=lambda e: (e.instante, e.titulo))
+        return self.eventos
+
+    def resolve_conflicts(self) -> List[str]:
+        """Retorna lista de IDs com datas conflitantes."""
+        seen: dict[str, int] = {}
+        conflicts: set[str] = set()
+        for ev in self.eventos:
+            prev = seen.get(ev.id)
+            if prev is not None and prev != ev.instante:
+                conflicts.add(ev.id)
+            seen[ev.id] = ev.instante
+        return sorted(conflicts)
+
+    def filter_by(
+        self,
+        *,
+        tipo: Optional[str] = None,
+        escopo: Optional[str] = None,
+        era: Optional[str] = None,
+        tag: Optional[str] = None,
+    ) -> List[Evento]:
+        """Filtra eventos por campos opcionais."""
+        result = self.eventos
+        if tipo is not None:
+            result = [e for e in result if e.tipo == tipo]
+        if escopo is not None:
+            result = [e for e in result if e.escopo == escopo]
+        if era is not None:
+            result = [e for e in result if e.era == era]
+        if tag is not None:
+            result = [e for e in result if tag in e.tags]
+        return result
+
+    def quick_create(self, date: int, snippet: str) -> Evento:
+        """Cria rapidamente um evento usando apenas data e trecho."""
+        evento = Evento(titulo=snippet.strip(), instante=date)
+        self.add_event(evento)
+        return evento
+
+
+# Instância global utilizada pelo editor e UI.
+timeline_service = TimelineService()

--- a/tests/timeline/test_service.py
+++ b/tests/timeline/test_service.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.timeline.service import Evento, TimelineService
+
+
+def test_sort_events_orders_by_year_and_title():
+    s = TimelineService([
+        Evento(titulo="B", instante=5),
+        Evento(titulo="A", instante=5),
+        Evento(titulo="C", instante=1),
+    ])
+    s.sort_events()
+    assert [e.titulo for e in s.eventos] == ["C", "A", "B"]
+
+
+def test_resolve_conflicts_detects_same_id_different_year():
+    ev1 = Evento(titulo="E1", instante=10, id="dup")
+    ev2 = Evento(titulo="E2", instante=12, id="dup")
+    s = TimelineService([ev1, ev2])
+    assert s.resolve_conflicts() == ["dup"]

--- a/ui/editor.py
+++ b/ui/editor.py
@@ -87,6 +87,7 @@ from .religioes_faccoes import MainWindow as ReligioesFaccoesWindow
 from .cidades_planetas import MainWindow as CidadesPlanetasWindow
 from .theme import apply_theme, load_theme, THEMES as AVAILABLE_THEMES
 from icons import icon
+from core.timeline.service import timeline_service
 
 class FavoriteFileSystemModel(QFileSystemModel):
     """File system model that highlights favorite paths."""
@@ -426,6 +427,16 @@ class SpellPlainTextEdit(QPlainTextEdit):
                 act.triggered.connect(
                     lambda _, c=QTextCursor(cursor), w=s: self._replace_word(c, w)
                 )
+        # opção de criação rápida de evento
+        selection = self.textCursor().selectedText()
+        m = re.search(r"(-?\d+)", selection)
+        if selection and m:
+            menu.addSeparator()
+            act = menu.addAction("Adicionar à Linha do Tempo")
+            date = int(m.group(1))
+            snippet = selection
+            act.triggered.connect(lambda: timeline_service.quick_create(date, snippet))
+
         menu.exec_(event.globalPos())
 
     def _replace_word(self, cursor, new_word):


### PR DESCRIPTION
## Summary
- introduce TimelineService for managing timeline events
- integrate timeline UI and editor quick-create with TimelineService
- add unit tests for event ordering and conflict detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a05927c08325af02b10f8e8816a2