### PR TITLE
Fix Phosphor icon asset path

### DIFF
--- a/ui/icons.py
+++ b/ui/icons.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QIcon, QPixmap, QColor, QPainter
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtSvg import QSvgRenderer
 
-BASE = Path(__file__).parent / "assets" / "icons" / "phosphor"
+BASE = Path(__file__).resolve().parent.parent / "assets" / "icons" / "phosphor" / "SVGs"
 DEFAULT_WEIGHT = "regular"
 
 ALIASES = {


### PR DESCRIPTION
## Summary
- fix Phosphor icon base directory to point to bundled SVG weights

## Testing
- `pre-commit run --files ui/icons.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b973d718848325aa3ef1aeb5049033