### PR TITLE
feat: remove networkx dependency

### DIFF
--- a/core/geo/routes.py
+++ b/core/geo/routes.py
@@ -1,10 +1,13 @@
-"""Utility for managing routes between settlements using networkx."""
+"""Utility for managing routes between settlements.
+
+Historically this module relied on :mod:`networkx` for its underlying data
+structure.  To keep dependencies small we now ship a tiny bespoke graph
+implementation that supports the limited feature set required.
+"""
 
 from __future__ import annotations
 
-from typing import Iterable, Literal
-
-import networkx as nx
+from typing import Dict, Iterable, Literal
 
 RouteType = Literal["terrestre", "fluvial", "maritimo"]
 
@@ -13,11 +16,11 @@ class RoutesGraph:
     """Graph of routes between settlements."""
 
     def __init__(self) -> None:
-        self.graph = nx.Graph()
+        self._adj: Dict[str, Dict[str, Dict[str, object]]] = {}
 
     def add_settlement(self, name: str) -> None:
         """Ensure a settlement node exists."""
-        self.graph.add_node(name)
+        self._adj.setdefault(name, {})
 
     def add_route(self, origem: str, destino: str, tipo: RouteType) -> None:
         """Add a route between two settlements."""
@@ -25,16 +28,23 @@ class RoutesGraph:
             raise ValueError("tipo must be terrestre, fluvial or maritimo")
         self.add_settlement(origem)
         self.add_settlement(destino)
-        self.graph.add_edge(origem, destino, tipo=tipo)
+        data = {"tipo": tipo}
+        self._adj[origem][destino] = data
+        self._adj[destino][origem] = data
 
     def remove_route(self, origem: str, destino: str) -> None:
-        if self.graph.has_edge(origem, destino):
-            self.graph.remove_edge(origem, destino)
+        self._adj.get(origem, {}).pop(destino, None)
+        self._adj.get(destino, {}).pop(origem, None)
 
     def neighbors(self, settlement: str) -> Iterable[str]:
-        return self.graph.neighbors(settlement)
+        return self._adj.get(settlement, {}).keys()
 
     def routes(self) -> Iterable[tuple[str, str, RouteType]]:
         """Iterate over stored routes."""
-        for u, v, data in self.graph.edges(data=True):
-            yield u, v, data.get("tipo", "terrestre")
+        seen = set()
+        for u, nbrs in self._adj.items():
+            for v, data in nbrs.items():
+                if (v, u) in seen:
+                    continue
+                seen.add((u, v))
+                yield u, v, data.get("tipo", "terrestre")

--- a/core/relations.py
+++ b/core/relations.py
@@ -1,16 +1,67 @@
 """Utility classes for managing bidirectional relations between entities.
 
-The :class:`RelationGraph` provides a lightweight interface around
-``networkx`` to register entities (characters, factions, locations, etc.)
-with bidirectional edges. It can be exported to a ``networkx.Graph`` for
-visualisation with any backend (matplotlib, pyvis, ...).
+The original implementation wrapped :mod:`networkx` directly which meant the
+library had to be installed even when only the basic data structure was
+required.  This module now provides a small in-house graph structure that
+covers the limited feature set we need (bidirectional edges with attributes)
+while keeping :mod:`networkx` as an optional dependency for visualisation.
 """
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Dict, Iterable
 
-import networkx as nx
+
+class _MiniGraph:
+    """Very small undirected graph with edge and node attributes.
+
+    The implementation is intentionally tiny – it only supports the handful of
+    operations required by :class:`RelationGraph`.  Nodes are stored in a
+    dictionary mapping to their neighbours and optional edge attribute
+    dictionaries.
+    """
+
+    def __init__(self) -> None:
+        self._adj: Dict[str, Dict[str, Dict[str, object]]] = {}
+        self._node_attrs: Dict[str, Dict[str, object]] = {}
+
+    # -- basic mutation -------------------------------------------------
+    def add_node(self, node: str, **attrs: object) -> None:
+        self._adj.setdefault(node, {})
+        if attrs:
+            self._node_attrs.setdefault(node, {}).update(attrs)
+
+    def add_edge(self, a: str, b: str, **attrs: object) -> None:
+        self.add_node(a)
+        self.add_node(b)
+        self._adj[a][b] = attrs
+        self._adj[b][a] = attrs
+
+    def remove_edge(self, a: str, b: str) -> None:
+        self._adj.get(a, {}).pop(b, None)
+        self._adj.get(b, {}).pop(a, None)
+
+    # -- helpers --------------------------------------------------------
+    def has_edge(self, a: str, b: str) -> bool:
+        return b in self._adj.get(a, {})
+
+    def neighbors(self, node: str) -> Dict[str, Dict[str, object]]:
+        return self._adj.get(node, {})
+
+    def nodes(self) -> Iterable[str]:
+        return self._adj.keys()
+
+    def node_attrs(self, node: str) -> Dict[str, object]:
+        return self._node_attrs.get(node, {})
+
+    def edges(self) -> Iterable[tuple[str, str, Dict[str, object]]]:
+        seen = set()
+        for a, nbrs in self._adj.items():
+            for b, data in nbrs.items():
+                if (b, a) in seen:
+                    continue
+                seen.add((a, b))
+                yield a, b, data
 
 
 class RelationGraph:
@@ -22,7 +73,7 @@ class RelationGraph:
     """
 
     def __init__(self) -> None:
-        self._graph = nx.Graph()
+        self._graph = _MiniGraph()
 
     def add_entity(self, entity_id: str, **attrs: object) -> None:
         """Register a new entity node in the graph."""
@@ -37,8 +88,7 @@ class RelationGraph:
     def remove_relation(self, a: str, b: str) -> None:
         """Remove the relation between ``a`` and ``b`` if it exists."""
 
-        if self._graph.has_edge(a, b):
-            self._graph.remove_edge(a, b)
+        self._graph.remove_edge(a, b)
 
     def relations_of(self, entity_id: str) -> Iterable[tuple[str, str]]:
         """Iterate over relations for ``entity_id``.
@@ -46,22 +96,46 @@ class RelationGraph:
         Yields tuples of ``(other_id, relation_type)``.
         """
 
-        for other, data in self._graph[entity_id].items():
+        for other, data in self._graph.neighbors(entity_id).items():
             yield other, data.get("relation", "")
 
-    def to_networkx(self) -> nx.Graph:
-        """Return the underlying ``networkx`` graph instance."""
+    def to_networkx(self):  # pragma: no cover - convenience helper
+        """Return a ``networkx.Graph`` representing the relations.
 
-        return self._graph
+        ``networkx`` is imported lazily so that it remains an optional
+        dependency.  A :class:`ModuleNotFoundError` is raised if the package is
+        missing.
+        """
+
+        try:
+            import networkx as nx  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - environment dep
+            raise ModuleNotFoundError(
+                "networkx is required for converting to a networkx.Graph"
+            ) from exc
+
+        g = nx.Graph()
+        for node in self._graph.nodes():
+            g.add_node(node, **self._graph.node_attrs(node))
+        for a, b, data in self._graph.edges():
+            g.add_edge(a, b, **data)
+        return g
 
     def plot(self) -> None:  # pragma: no cover - optional UI helper
         """Quick visualisation using ``matplotlib``.
 
-        This method imports ``matplotlib`` lazily to avoid forcing the
-        dependency for users that only need the data structure.
+        Both :mod:`networkx` and :mod:`matplotlib` are imported lazily to avoid
+        forcing the dependencies for users that only need the data structure.
         """
 
-        import matplotlib.pyplot as plt
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError("matplotlib is required for plotting") from exc
 
-        nx.draw_networkx(self._graph)
+        nx_graph = self.to_networkx()
+        # networkx will be imported by ``to_networkx``
+        import networkx as nx  # type: ignore
+
+        nx.draw_networkx(nx_graph)
         plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ PyQt5
 pyspellchecker
 pydantic
 python-dotenv
-networkx
 matplotlib
 python-docx


### PR DESCRIPTION
## Summary
- drop hard dependency on networkx by introducing lightweight in-house graph structures
- update relation and route graphs to use custom adjacency maps with lazy networkx/matplotlib imports for optional features
- clean up requirements to reflect new optional dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97d08c60883258328a7a63a1c2f72